### PR TITLE
fix help command bug, create `links` table remotely and add chat_ids variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,12 +42,32 @@ git clone https://github.com/XiangpengHao/seen.git
 cd seen
 ```
 
-#### Setup Telegram 
-Add your Telegram bot token to Cloudflare Workers as a secret:
-```bash
-wrangler secret put BOT_TOKEN
-```
-When prompted, paste your Telegram bot token.
+#### Setup Telegram
+
+1. Add your Telegram bot token to Cloudflare Workers as a secret:
+
+    ```bash
+    wrangler secret put BOT_TOKEN
+    ```
+    
+    When prompted, paste your Telegram bot token.
+
+2. Get your Chat ID by sending a message to your bot and then visiting: 
+
+    ```
+    https://api.telegram.org/bot<BOT_TOKEN>/getUpdates
+    ```
+    
+    Replace <BOT_TOKEN> with your actual bot token. Look for the `chat` object in the response and find your `id`.
+
+3. Add your Chat ID to the environment variables in your wrangler.toml file:
+
+    ```toml
+    [vars]
+    AUTHORIZED_CHAT_IDS = "YOUR_CHAT_ID"
+    ```
+
+    Replace YOUR_CHAT_ID with the chat ID you obtained in the previous step. For multiple authorized users, separate IDs with commas: "ID1,ID2,ID3".
 
 #### Setup CloudFlare
 Add your [CloudFlare account ID and API token](https://developers.cloudflare.com/fundamentals/api/get-started/account-owned-tokens/) to Cloudflare Workers as secrets:
@@ -79,7 +99,7 @@ database_id = "bba483bb-4377-46f1-a8d4-df83772edc95"
 
 Configure the database:
 ```bash
-npx wrangler d1 execute seen --command "SQL_BELOW"
+npx wrangler d1 execute seen --command "SQL_BELOW" --remote
 ```
 
 ```sql

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -25,3 +25,6 @@ index_name = "seen-index"
 
 [ai]
 binding = "AI"
+
+[vars]
+AUTHORIZED_CHAT_IDS = "132580810,-4588732846,-4230053857"


### PR DESCRIPTION
Thanks for this interesting robot!

I had some problems trying to deploy it, I tried fixing it and it runs fine for now, but I'm not so sure the modifications are as expected

### fix help command bug

**before**

meet error with `parse_mode":"HTML"`, I see in the log that it keeps sending `help command` in a loop. 
```
  (error) Failed to send message: Status 400, message: {"chat_id":XXXXX,"parse_mode":"HTML","text":"Available commands:\n/start - Start the bot\n/help - Show this help message\n/list - Show link statistics\n/search <query> - Search through saved links\n/delete <url> - Delete a saved link\nOr simply send a URL to save it, or any text to search for it."}
```

**after**
<img width="555" alt="image" src="https://github.com/user-attachments/assets/b69143ce-044c-439c-9210-23f5f212b018" />


### create `links` table remotely
meet error without `--remote`
```
  (error) Error handling link: https://arxiv.org/pdf/2405.01418, error: D1: D1Error {
    cause: JsValue(Error: no such table: links: SQLITE_ERROR
    Error: no such table: links: SQLITE_ERROR
        at D1DatabaseSessionAlwaysPrimary._sendOrThrow (cloudflare-internal:d1-api:130:24)
        at async D1PreparedStatement.run (cloudflare-internal:d1-api:308:29)),
}
```

### add AUTHORIZED_CHAT_IDS variable

Not sure if I need to support this conf, as checking the docs shows that variable doesn't seem to be able to be changed via the wrangler ctl 🤔
   - [env doc](https://developers.cloudflare.com/workers/configuration/environment-variables/)
   - secret can use `npx wrangler secret put <KEY>`
   
  